### PR TITLE
Bugfix (syntax error) in GraphViz.jl

### DIFF
--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -614,7 +614,6 @@ module GraphViz
                 nothing
             end     
         end
-        =#
     end
 
     graph_plugins(c::Context) = Graph(ccall((:gvPluginsGraph,gvc),Ptr{Void},(Ptr{Void},),c.handle))


### PR DESCRIPTION
"=#" on line 617 caused syntax error when `using GraphViz`.
