### PR TITLE
update BinDeps usage

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -26,4 +26,4 @@ provides(BuildProcess,Autotools(libtarget = "lib/cgraph/.libs/libcgraph."*BinDep
 # Ubuntu GraphViz is too old
 # provides(AptGet,"graphviz",graphviz)
 
-@BinDeps.install
+@BinDeps.install [ :cgraph => :cgraph, :gvc => :gvc ]

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -1,6 +1,9 @@
 module GraphViz
-    using BinDeps
-    @BinDeps.load_dependencies
+    if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
+        include("../deps/deps.jl")
+    else
+        error("GraphViz not properly installed. Please run Pkg.build(\"GraphViz\").")
+    end
 
     # Plugin Struct
 


### PR DESCRIPTION
The recent updates to BinDeps have left GraphViz unloadable.
