### PR TITLE
Define pango environment variables to avoid warnings

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,6 +19,7 @@ graphviz = [cgraph,gvc]
     module GraphVizInit
     function __init__()
         ENV["GVBINDIR"] = Pkg.dir("Homebrew","deps","usr","lib","graphviz")
+        ENV["PANGO_SYSCONFDIR"] = joinpath("$(Homebrew.prefix())", "etc")
     end
     __init__()
     end


### PR DESCRIPTION
Should resolve issues in https://github.com/Keno/GraphViz.jl/issues/13#issuecomment-69943687
