### PR TITLE
remove "open" from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ If you already have a graph you would like to work with, the following code snip
 at the "Simple Examples" section below
 ```
 using GraphViz
-open(Graph,"mygraph.dot")
 Graph("""
  digraph graphname {
      a -> b -> c;


### PR DESCRIPTION
I don't see any open function exported by GraphViz - without this line everything works fine.