### PR TITLE
WIP: Port to Julia v0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+deps/build.log
 deps/deps.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "GraphViz"
+uuid = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
+version = "0.1.1"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Homebrew = "d9be37ee-ecc9-5288-90f1-b9ca67657a75"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.7
 BinDeps
 @osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,8 +1,11 @@
 using BinDeps
 
+import Cairo
+const cairo_dir = joinpath(dirname(pathof(Cairo)), "..")
+
 # Configuration / Autodetections
-const x11 = is_unix() ? !is_apple() : false
-const gtk = isdir(Pkg.dir("Gtk"))
+const x11 = Sys.isunix() ? !Sys.isapple() : false
+const gtk = try import Gtk; true catch; false end
 
 @BinDeps.setup
 
@@ -13,12 +16,13 @@ gvc = library_dependency("gvc",aliases = ["libgvc"])
 
 graphviz = [cgraph,gvc]
 
-if is_apple()
+if Sys.isapple()
     using Homebrew
     provides( Homebrew.HB, "graphviz", graphviz, os = :Darwin, preload = """
     module GraphVizInit
+    import Homebrew
     function __init__()
-        ENV["GVBINDIR"] = Pkg.dir("Homebrew","deps","usr","lib","graphviz")
+        ENV["GVBINDIR"] = joinpath(dirname(pathof(Homebrew)),"..","deps","usr","lib","graphviz")
         ENV["PANGO_SYSCONFDIR"] = joinpath("$(Homebrew.prefix())", "etc")
     end
     __init__()
@@ -35,7 +39,7 @@ push!(options,"--enable-debug")
 
 provides(Sources,URI("http://www.graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.36.0.tar.gz"),graphviz)
 provides(BuildProcess,Autotools(libtarget = "lib/cgraph/.libs/libcgraph."*BinDeps.shlib_ext,configure_options=options,
-    pkg_config_dirs=[Pkg.dir("Cairo","deps","usr","lib","pkgconfig")]),graphviz)
+    pkg_config_dirs=[joinpath(cairo_dir,"deps","usr","lib","pkgconfig")]),graphviz)
 
 # Ubuntu GraphViz is too old
 # provides(AptGet,"graphviz",graphviz)

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -7,18 +7,18 @@ module GraphViz
 
     # Plugin Struct
 
-    immutable gvdevice_engine_t
-        initialize::Ptr{Void}
-        format::Ptr{Void}
-        finalize::Ptr{Void}
+    struct gvdevice_engine_t
+        initialize::Ptr{Cvoid}
+        format::Ptr{Cvoid}
+        finalize::Ptr{Cvoid}
     end
 
-    immutable Pointf
+    struct Pointf
         x::Float64
         y::Float64
     end
 
-    immutable gvdevice_features_t
+    struct gvdevice_features_t
         flags::Cint
         default_margin_x::Float64
         default_margin_y::Float64
@@ -28,7 +28,7 @@ module GraphViz
         default_dpi_y::Float64
     end
 
-    immutable gvplugin_installed_t
+    struct gvplugin_installed_t
         id::Cint
         ctype::Ptr{UInt8}
         quality::Cint
@@ -72,82 +72,82 @@ module GraphViz
     const OUTPUT_NOT_REQUIRED           = (1<<27)
 
 
-    immutable gvplugin_api_t
+    struct gvplugin_api_t
         api::Cint
         types::Ptr{gvplugin_installed_t}
     end
 
-    immutable gvplugin_library_t
+    struct gvplugin_library_t
         name::Ptr{UInt8}
         apis::Ptr{gvplugin_api_t}
     end
 
     # Job Struct
 
-    immutable gvplugin_active_device_t
+    struct gvplugin_active_device_t
         engine::Ptr{gvdevice_engine_t}
         id::Cint
         features::Ptr{gvdevice_features_t}
         ctype::Ptr{UInt8}
     end
 
-    immutable gvplugin_active_render_t
-        engine::Ptr{Void}
+    struct gvplugin_active_render_t
+        engine::Ptr{Cvoid}
         id::Cint
-        features::Ptr{Void}
+        features::Ptr{Cvoid}
         ctype::Ptr{UInt8}
     end
 
-    immutable gvplugin_active_loadimage_t
-        engine::Ptr{Void}
+    struct gvplugin_active_loadimage_t
+        engine::Ptr{Cvoid}
         id::Cint
         ctype::Ptr{UInt8}
     end
 
-    immutable gv_argvlist_t
+    struct gv_argvlist_t
         argv::Ptr{Ptr{UInt8}}
         argc::Cint;
         alloc::Cint;
     end
 
-    immutable Point{T}
+    struct Point{T}
         x::T
         y::T
     end
 
-    immutable Box{T}
+    struct Box{T}
         topleft::Point{T}
         bottomright::Point{T}
     end
 
-    immutable gvdevice_callback_t
-        refresh::Ptr{Void}          # void (*refresh) (GVJ_t * job);
-        button_press::Ptr{Void}     # void (*button_press) (GVJ_t * job, int button, pointf pointer);
-        button_release::Ptr{Void}   # void (*button_release) (GVJ_t * job, int button, pointf pointer);
-        motion::Ptr{Void}           # void (*motion) (GVJ_t * job, pointf pointer);
-        modify::Ptr{Void}           # void (*modify) (GVJ_t * job, const char *name, const char *value);
-        del::Ptr{Void}              # void (*del) (GVJ_t * job);  /* can't use "delete" 'cos C++ stole it */
-        read::Ptr{Void}             # void (*read) (GVJ_t * job, const char *filename, const char *layout);
-        layout::Ptr{Void}           # void (*layout) (GVJ_t * job, const char *layout);
-        render::Ptr{Void}           # void (*render) (GVJ_t * job, const char *format, const char *filename);
+    struct gvdevice_callback_t
+        refresh::Ptr{Cvoid}          # void (*refresh) (GVJ_t * job);
+        button_press::Ptr{Cvoid}     # void (*button_press) (GVJ_t * job, int button, pointf pointer);
+        button_release::Ptr{Cvoid}   # void (*button_release) (GVJ_t * job, int button, pointf pointer);
+        motion::Ptr{Cvoid}           # void (*motion) (GVJ_t * job, pointf pointer);
+        modify::Ptr{Cvoid}           # void (*modify) (GVJ_t * job, const char *name, const char *value);
+        del::Ptr{Cvoid}              # void (*del) (GVJ_t * job);  /* can't use "delete" 'cos C++ stole it */
+        read::Ptr{Cvoid}             # void (*read) (GVJ_t * job, const char *filename, const char *layout);
+        layout::Ptr{Cvoid}           # void (*layout) (GVJ_t * job, const char *layout);
+        render::Ptr{Cvoid}           # void (*render) (GVJ_t * job, const char *format, const char *filename);
     end
 
     # TODO: These are probably wrong
-    type GVCOMMON_s
+    mutable struct GVCOMMON_s
         info::Ptr{Ptr{UInt8}}
         cmdname::Ptr{UInt8}
         verbose::Cint
         config::UInt8
         auto_outfile_names::UInt8
-        errorfn::Ptr{Void}
-        show_boxes::Ptr{Ptr{Void}}
-        lib::Ptr{Ptr{Void}}
+        errorfn::Ptr{Cvoid}
+        show_boxes::Ptr{Ptr{Cvoid}}
+        lib::Ptr{Ptr{Cvoid}}
         viewNum::Cint
-        builtins::Ptr{Void}
+        builtins::Ptr{Cvoid}
         demand_loading::Cint
     end
 
-    type GVC_s
+    mutable struct GVC_s
         common::GVCOMMON_s
 
         config_path::Ptr{UInt8}
@@ -155,43 +155,43 @@ module GraphViz
 
         input_filenames::Ptr{Ptr{UInt8}}
 
-        gvgs::Ptr{Void}
-        gvg::Ptr{Void}
+        gvgs::Ptr{Cvoid}
+        gvg::Ptr{Cvoid}
 
         # Hack until tuples are properly inlined into types
-        apis0::Ptr{Void}
-        apis1::Ptr{Void}
-        apis2::Ptr{Void}
-        apis3::Ptr{Void}
-        apis4::Ptr{Void}
-        api0::Ptr{Void}
-        api1::Ptr{Void}
-        api2::Ptr{Void}
-        api3::Ptr{Void}
-        api4::Ptr{Void}
-        packages::Ptr{Void}
+        apis0::Ptr{Cvoid}
+        apis1::Ptr{Cvoid}
+        apis2::Ptr{Cvoid}
+        apis3::Ptr{Cvoid}
+        apis4::Ptr{Cvoid}
+        api0::Ptr{Cvoid}
+        api1::Ptr{Cvoid}
+        api2::Ptr{Cvoid}
+        api3::Ptr{Cvoid}
+        api4::Ptr{Cvoid}
+        packages::Ptr{Cvoid}
 
         #  size_t (*write_fn) (GVJ_t *job, const char *s, size_t len);
-        write_fn::Ptr{Void}
+        write_fn::Ptr{Cvoid}
 
         # More stuff I don't need right now
     end
 
-    type GVJ_s
+    mutable struct GVJ_s
         gvc::Ptr{GVC_s}
         next::Ptr{GVJ_s}
         next_active::Ptr{GVJ_s}
 
-        common::Ptr{Void}
+        common::Ptr{Cvoid}
 
-        obj_state::Ptr{Void}
+        obj_state::Ptr{Cvoid}
         input_filename::Ptr{UInt8}
         graph_index::Cint
 
         layout_type::Ptr{UInt8}
 
         output_filename::Ptr{UInt8}
-        output_file::Ptr{Void}
+        output_file::Ptr{Cvoid}
         output_data::Ptr{UInt8}
         output_data_allocated::Cuint
         output_data_position::Cuint
@@ -208,10 +208,10 @@ module GraphViz
         device_dpi::Pointf
         device_sets_dpi::UInt8
 
-        displat::Ptr{Void}
+        displat::Ptr{Cvoid}
         screen::Cint
 
-        context::Ptr{Void}
+        context::Ptr{Cvoid}
         external_context::UInt8
 
         imagedata::Ptr{UInt8}
@@ -264,8 +264,8 @@ module GraphViz
         pointer::Point{Float64}
         oldpointer::Point{Float64}
 
-        current_obj::Ptr{Void}
-        selected_obj::Ptr{Void}
+        current_obj::Ptr{Cvoid}
+        selected_obj::Ptr{Cvoid}
 
         active_tooltip::Ptr{UInt8}
         selected_href::Ptr{UInt8}
@@ -273,80 +273,80 @@ module GraphViz
         selected_obj_type_name::gv_argvlist_t
         selected_obj_attributes::gv_argvlist_t
 
-        window::Ptr{Void}
+        window::Ptr{Cvoid}
 
-        keybindings::Ptr{Void}
+        keybindings::Ptr{Cvoid}
         numkeys::Cint
-        keycodes::Ptr{Void}
+        keycodes::Ptr{Cvoid}
     end
 
     # Disciplines
 
 
-    immutable Agmemdisc_s      
+    struct Agmemdisc_s      
         #void *(*open) (Agdisc_t*);  /* independent of other resources */
-        open::Ptr{Void}
+        open::Ptr{Cvoid}
         #void *(*alloc) (void *state, size_t req);
-        alloc::Ptr{Void}
+        alloc::Ptr{Cvoid}
         #void *(*resize) (void *state, void *ptr, size_t old, size_t req);
-        resize::Ptr{Void}
+        resize::Ptr{Cvoid}
         # void (*free) (void *state, void *ptr);
-        free::Ptr{Void}
+        free::Ptr{Cvoid}
         # void (*close) (void *state);
-        close::Ptr{Void}
+        close::Ptr{Cvoid}
     end
 
-    immutable Agiddisc_s
+    struct Agiddisc_s
         # void *(*open) (Agraph_t * g, Agdisc_t*);    /* associated with a graph */
-        open::Ptr{Void}
+        open::Ptr{Cvoid}
         # long (*map) (void *state, int objtype, char *str, unsigned long *id, int createflag);
-        map::Ptr{Void}
+        map::Ptr{Cvoid}
         # long (*alloc) (void *state, int objtype, unsigned long id);
-        alloc::Ptr{Void}
+        alloc::Ptr{Cvoid}
         #void (*free) (void *state, int objtype, unsigned long id);
-        free::Ptr{Void}
+        free::Ptr{Cvoid}
         #char *(*print) (void *state, int objtype, unsigned long id);
-        print::Ptr{Void}
+        print::Ptr{Cvoid}
         #void (*close) (void *state);
-        close::Ptr{Void}
+        close::Ptr{Cvoid}
         #void (*idregister) (void *state, int objtype, void *obj);
-        idregister::Ptr{Void}
+        idregister::Ptr{Cvoid}
     end
 
-    immutable Agiodisc_s
+    struct Agiodisc_s
         # int (*afread) (void *chan, char *buf, int bufsize);
-        afread::Ptr{Void}
+        afread::Ptr{Cvoid}
         # int (*putstr) (void *chan, const char *str);
-        putstr::Ptr{Void}
+        putstr::Ptr{Cvoid}
         # int (*flush) (void *chan);  /* sync */
-        flush::Ptr{Void}
+        flush::Ptr{Cvoid}
     end
 
-    immutable Agdisc_s
+    struct Agdisc_s
         mem::Ptr{Agmemdisc_s}
         id::Ptr{Agiddisc_s}
         io::Ptr{Agiodisc_s}
     end
 
-    function jl_afread(io::Ptr{Void}, buf::Ptr{UInt8}, bufsize::Cint)
+    function jl_afread(io::Ptr{Cvoid}, buf::Ptr{UInt8}, bufsize::Cint)
         #@show (io,buf,bufsize)
         ret = readbytes!(unsafe_pointer_to_objref(io)::IO,unsafe_wrap(Array,buf,Int(bufsize)))
         #@show ret
         convert(Cint,ret)
     end
 
-    function jl_putstr(io::Ptr{Void}, str::Ptr{UInt8})
+    function jl_putstr(io::Ptr{Cvoid}, str::Ptr{UInt8})
         #@show (io,str)
         convert(Cint,write(unsafe_pointer_to_objref(io)::IO,unsafe_wrap(Array,str,Int(ccall(:strlen,Csize_t,(Ptr{UInt8},),str)))))::Cint
     end
 
-    jl_flush(io::Ptr{Void}) = convert(Cint,0)
+    jl_flush(io::Ptr{Cvoid}) = convert(Cint,0)
 
 
     const JuliaIODisc = [Agiodisc_s(
-        cfunction(jl_afread,Cint,(Ptr{Void},Ptr{UInt8},Cint)),
-        cfunction(jl_putstr,Cint,(Ptr{Void},Ptr{UInt8})),
-        cfunction(jl_flush,Cint,(Ptr{Void},))
+        @cfunction(jl_afread,Cint,(Ptr{Cvoid},Ptr{UInt8},Cint)),
+        @cfunction(jl_putstr,Cint,(Ptr{Cvoid},Ptr{UInt8})),
+        @cfunction(jl_flush,Cint,(Ptr{Cvoid},))
     )]
 
 
@@ -360,18 +360,18 @@ module GraphViz
 
     # API - Context
 
-    type Context
-        handle::Ptr{Void}
+    mutable struct Context
+        handle::Ptr{Cvoid}
         function Context() 
-            this = new(ccall((:gvContext,gvc),Ptr{Void},()))
-            finalizer(this,free)
+            this = new(ccall((:gvContext,gvc),Ptr{Cvoid},()))
+            finalizer(free,this)
             this
         end
     end
 
     function free(t::Context) 
         if t.handle != C_NULL
-            ccall((:gvFreeContext,gvc), Void, (Ptr{Void},), t.handle)
+            ccall((:gvFreeContext,gvc), Cvoid, (Ptr{Cvoid},), t.handle)
         end
         t.handle = C_NULL
     end
@@ -380,10 +380,10 @@ module GraphViz
 
     export Graph
 
-    type Graph
-        handle::Ptr{Void}
+    mutable struct Graph
+        handle::Ptr{Cvoid}
         didlayout::Bool
-        function Graph(p::Ptr{Void})
+        function Graph(p::Ptr{Cvoid})
             this = new(p,false)
             finalizer(this,free)
             this
@@ -392,40 +392,40 @@ module GraphViz
 
     function free(g::Graph)
         if g.handle != C_NULL
-            ccall((:agclose,cgraph), Cint, (Ptr{Void},), g.handle)
+            ccall((:agclose,cgraph), Cint, (Ptr{Cvoid},), g.handle)
         end
         g.handle = C_NULL
     end
 
-    Graph(graph::IO) = Graph(ccall((:agread,cgraph),Ptr{Void},(Any,Ptr{Void}),graph,[Agdisc_s(
+    Graph(graph::IO) = Graph(ccall((:agread,cgraph),Ptr{Cvoid},(Any,Ptr{Cvoid}),graph,[Agdisc_s(
         cglobal((:AgMemDisc,cgraph)),
         cglobal((:AgIdDisc,cgraph)),
         pointer(JuliaIODisc)
         )]))
     Graph(graph::Vector{UInt8}) = Graph(IOBuffer(graph))
-    Graph(graph::String) = Graph(Vector{UInt8}(graph))
+    Graph(graph::String) = Graph(unsafe_wrap(Vector{UInt8}, graph))
 
     function layout!(g::Graph;engine="neato", context = default_context)
         @assert g.handle != C_NULL
-        ccall((:gvLayout,gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8}),context.handle,g.handle,engine)
+        ccall((:gvLayout,gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8}),context.handle,g.handle,engine)
         g.didlayout = true
     end
 
-    render_x11(c::Context,g::Graph) = ccall((:gvRender,gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8},Ptr{Void}),c.handle,g.handle,"x11",C_NULL)
-    render_jobs(c::Context,g::Graph) = ccall((:gvRenderJobs,gvc),Cint,(Ptr{Void},Ptr{Void}),c.handle,g.handle)
+    render_x11(c::Context,g::Graph) = ccall((:gvRender,gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),c.handle,g.handle,"x11",C_NULL)
+    render_jobs(c::Context,g::Graph) = ccall((:gvRenderJobs,gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid}),c.handle,g.handle)
 
     # Render
 
     # IO device
 
-    type IODeviceState
+    mutable struct IODeviceState
         io::IO
-        oldwritefn::Ptr{Void}
+        oldwritefn::Ptr{Cvoid}
     end
 
-    const active_devices = ObjectIdDict()
+    const active_devices = IdDict()
 
-    function jlio_write(job::Ptr{Void},s::Ptr{UInt8},len::Csize_t)
+    function jlio_write(job::Ptr{Cvoid},s::Ptr{UInt8},len::Csize_t)
         job = unsafe_load(convert(Ptr{GVJ_s},job))
         ioc = unsafe_pointer_to_objref(job.context)::IODeviceState
         write(ioc.io,unsafe_wrap(Array,s,Int(len)))
@@ -435,24 +435,24 @@ module GraphViz
     # determined by counting bytes ;)
     const WRITEFN_OFFSET = 200
 
-    function julia_io_initialize(firstjob::Ptr{Void})
+    function julia_io_initialize(firstjob::Ptr{Cvoid})
         #@show firstjob
         firstjob = convert(Ptr{GVJ_s},firstjob)
         job = unsafe_load(firstjob)
         # Temporarily put in our custom write function
         ioc = unsafe_pointer_to_objref(job.context)::IODeviceState
-        writefnptr = convert(Ptr{Ptr{Void}},job.gvc+WRITEFN_OFFSET)
+        writefnptr = convert(Ptr{Ptr{Cvoid}},job.gvc+WRITEFN_OFFSET)
         ioc.oldwritefn = unsafe_load(writefnptr)
-        unsafe_store!(writefnptr,cfunction(jlio_write,Csize_t,(Ptr{Void},Ptr{UInt8},Csize_t)))
+        unsafe_store!(writefnptr,@cfunction(jlio_write,Csize_t,(Ptr{Cvoid},Ptr{UInt8},Csize_t)))
         # This function has void return
         nothing
     end
-    function julia_io_finalize(firstjob::Ptr{Void}) 
+    function julia_io_finalize(firstjob::Ptr{Cvoid}) 
         # Reset the write pointer we changed in julia_io_initialize
         firstjob = convert(Ptr{GVJ_s},firstjob)
         job = unsafe_load(firstjob)
         ioc = unsafe_pointer_to_objref(job.context)::IODeviceState
-        writefnptr = convert(Ptr{Ptr{Void}},job.gvc+WRITEFN_OFFSET)
+        writefnptr = convert(Ptr{Ptr{Cvoid}},job.gvc+WRITEFN_OFFSET)
         unsafe_store!(writefnptr,ioc.oldwritefn)
         # Also remove it from the gc preserve dict
         haskey(active_devices,ioc) && pop!(active_devices,ioc)
@@ -461,10 +461,10 @@ module GraphViz
 
     const default_context = GraphViz.Context()
 
-    const julia_io_engine = [ gvdevice_engine_t(cfunction(julia_io_initialize,Void,(Ptr{Void},)),C_NULL,cfunction(julia_io_finalize,Void,(Ptr{Void},))) ]
+    const julia_io_engine = [ gvdevice_engine_t(@cfunction(julia_io_initialize,Cvoid,(Ptr{Cvoid},)),C_NULL,@cfunction(julia_io_finalize,Cvoid,(Ptr{Cvoid},))) ]
     const julia_io_features = [ gvdevice_features_t(Int32(GVDEVICE_DOES_TRUECOLOR|GVDEVICE_DOES_LAYERS),0.,0.,0.,0.,72.,72.) ]
-    const julia_io_name = Vector{UInt8}("julia_io:svg")
-    const julia_io_libname = Vector{UInt8}("julia_io")
+    const julia_io_name = unsafe_wrap(Vector{UInt8}, "julia_io:svg")
+    const julia_io_libname = unsafe_wrap(Vector{UInt8}, "julia_io")
     const julia_io_device = 
     [ 
       gvplugin_installed_t(Int32(0),pointer(julia_io_name), Int32(0), pointer(julia_io_engine), pointer(julia_io_features));
@@ -476,7 +476,7 @@ module GraphViz
         null(gvplugin_api_t)
     ]
 
-    add_julia_io!(c::Context) = ccall((:gvAddLibrary,gvc),Void,(Ptr{Void},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(julia_io_libname),pointer(julia_io_api))])
+    add_julia_io!(c::Context) = ccall((:gvAddLibrary,gvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(julia_io_libname),pointer(julia_io_api))])
 
     function render(io::IO,g::GraphViz.Graph; context = default_context, format="julia_io:svg")
         GraphViz.add_julia_io!(context)
@@ -485,7 +485,7 @@ module GraphViz
         end
         state = IODeviceState(io,C_NULL)
         active_devices[state] = state
-        ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8},Any),context.handle,g.handle,format,state)
+        ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,state)
     end
 
     function Base.show(io::IO, ::MIME"image/svg+xml", x::Graph)
@@ -497,163 +497,161 @@ module GraphViz
 
     # Cairo device
 
-    if isdir(Pkg.dir("Cairo"))
-        using Cairo
+    using Cairo
 
-        function cairo_initialize(firstjob::Ptr{Void})
+    function cairo_initialize(firstjob::Ptr{Cvoid})
+        firstjob = convert(Ptr{GVJ_s},firstjob)
+        job = unsafe_load(firstjob)
+        if job.context != C_NULL
+            c = unsafe_pointer_to_objref(job.context)::CairoContext
+            job.context = c.ptr
+            job.external_context    = 0x1
+            job.width = width(c.surface)
+            job.height = height(c.surface)
+            unsafe_store!(firstjob,job)
+        else
+            job.external_context = 1
+            unsafe_store!(firstjob,job)
+            global last_surface = firstjob
+        end
+        nothing
+    end
+
+    global last_surface = nothing
+
+    function cairo_finalize(firstjob::Ptr{Cvoid})
+        #=firstjob = convert(Ptr{GVJ_s},firstjob)
+        job = unsafe_load(firstjob)
+        if last_surface == firstjob
+            surface = ccall((:cairo_get_target,Cairo._jl_libcairo),Ptr{Cvoid},(Ptr{Cvoid},),job.context)
+            last_surface = CairoSurface(surface, job.width, job.height)
+        end=#
+        nothing
+    end
+
+    function cairo_format(firstjob::Ptr{Cvoid})
+        global last_surface
+        firstjob = convert(Ptr{GVJ_s},firstjob)
+        job = unsafe_load(firstjob)
+        if last_surface == firstjob
+            surface = ccall((:cairo_get_target,Cairo._jl_libcairo),Ptr{Cvoid},(Ptr{Cvoid},),job.context)
+            last_surface = CairoSurface(surface, job.width, job.height)
+        end
+        nothing
+    end
+
+    const generic_cairo_engine = [ gvdevice_engine_t(@cfunction(cairo_initialize,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_format,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_finalize,Cvoid,(Ptr{Cvoid},))) ]
+    const generic_cairo_features = [ gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.) ]
+    const generic_cairo_features_interactive = [ gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.) ]
+    const generic_cairo_name = unsafe_wrap(Vector{UInt8}, "julia:cairo")
+    const generic_cairo_libname = unsafe_wrap(Vector{UInt8}, "julia:cairo")
+    const generic_cairo_device = 
+    [ 
+      gvplugin_installed_t(Int32(0),pointer(generic_cairo_name), Int32(0), pointer(generic_cairo_engine), pointer(generic_cairo_features));
+      null(gvplugin_installed_t)
+    ]
+    const generic_cairo_api = 
+    [
+        gvplugin_api_t(API_device, pointer(generic_cairo_device))
+        null(gvplugin_api_t)
+    ]
+
+    add_julia_cairo!(c::Context) = ccall((:gvAddLibrary,gvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(generic_cairo_libname),pointer(generic_cairo_api))])
+
+    function render(c::CairoContext,g::GraphViz.Graph; context = default_context, format="julia:cairo")
+        GraphViz.add_julia_cairo!(context)
+        if !g.didlayout
+            error("Must call layout before calling render!")
+        end
+        ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,c)
+    end
+
+    function cairo_render(g::GraphViz.Graph; context = default_context, format="julia:cairo")
+        global last_surface
+        GraphViz.add_julia_cairo!(context)
+        if !g.didlayout
+            error("Must call layout before calling render!")
+        end
+        ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),context.handle,g.handle,format,C_NULL)
+        surface = last_surface
+        last_surface = nothing
+        return surface
+    end
+
+    function Base.show(io::IO, m::MIME"image/png", x::Graph)
+        if !x.didlayout
+            layout!(x,engine="dot")
+        end
+        show(io, m, cairo_render(x))
+    end
+    #=
+    if isdir(Pkg.dir("Gtk"))
+        using Gtk
+
+        function gtk_initialize(firstjob::Ptr{Cvoid})
             firstjob = convert(Ptr{GVJ_s},firstjob)
             job = unsafe_load(firstjob)
-            if job.context != C_NULL
-                c = unsafe_pointer_to_objref(job.context)::CairoContext
-                job.context = c.ptr
-                job.external_context    = 0x1
-                job.width = width(c.surface)
-                job.height = height(c.surface)
-                unsafe_store!(firstjob,job)
-            else
-                job.external_context = 1
-                unsafe_store!(firstjob,job)
-                global last_surface = firstjob
-            end
+            c = unsafe_pointer_to_objref(job.context)::Gtk.Canvas
+            c.data = firstjob
+            job.context = getgc(c).ptr
+            job.window = pointer_from_objref(c)
+            unsafe_store!(firstjob,job)
             nothing
         end
 
-        global last_surface = nothing
-
-        function cairo_finalize(firstjob::Ptr{Void})
-            #=firstjob = convert(Ptr{GVJ_s},firstjob)
-            job = unsafe_load(firstjob)
-            if last_surface == firstjob
-                surface = ccall((:cairo_get_target,Cairo._jl_libcairo),Ptr{Void},(Ptr{Void},),job.context)
-                last_surface = CairoSurface(surface, job.width, job.height)
-            end=#
-            nothing
-        end
-
-        function cairo_format(firstjob::Ptr{Void})
-            global last_surface
+        function gtk_finalize(firstjob::Ptr{Cvoid})
             firstjob = convert(Ptr{GVJ_s},firstjob)
             job = unsafe_load(firstjob)
-            if last_surface == firstjob
-                surface = ccall((:cairo_get_target,Cairo._jl_libcairo),Ptr{Void},(Ptr{Void},),job.context)
-                last_surface = CairoSurface(surface, job.width, job.height)
-            end
+            c = unsafe_pointer_to_objref(job.window)::Gtk.Canvas
+            draw(gtk_update,c)
+            wait() #TODO: Make conditional on closing the widget
             nothing
-        end
+        end 
 
-        const generic_cairo_engine = [ gvdevice_engine_t(cfunction(cairo_initialize,Void,(Ptr{Void},)),cfunction(cairo_format,Void,(Ptr{Void},)),cfunction(cairo_finalize,Void,(Ptr{Void},))) ]
-        const generic_cairo_features = [ gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.) ]
-        const generic_cairo_features_interactive = [ gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.) ]
-        const generic_cairo_name = Vector{UInt8}("julia:cairo")
-        const generic_cairo_libname = Vector{UInt8}("julia:cairo")
-        const generic_cairo_device = 
+        function gtk_update(c::Canvas)
+            jobp = c.data::Ptr{GVJ_s}
+            job = unsafe_load(jobp)
+            job.height              = height(c)
+            job.width               = width(c)
+            job.context             = getgc(c).ptr
+            job.external_context    = 0x1
+            unsafe_store!(jobp,job)
+            println(job.callbacks)
+            println(unsafe_load(job.callbacks).refresh)
+            ccall(unsafe_load(job.callbacks).refresh,Cvoid,(Ptr{Cvoid},),jobp)
+        end
+        const gtk_engine = [ gvdevice_engine_t(@cfunction(gtk_initialize,Cvoid,(Ptr{Cvoid},)),C_NULL,@cfunction(gtk_finalize,Cvoid,(Ptr{Cvoid},))) ]
+        const gtk_features = [ gvdevice_features_t(Int32(GVDEVICE_EVENTS),0.,0.,0.,0.,96.,96.) ]
+        const gtk_name = unsafe_wrap(Vector{UInt8}, "julia_gtk:cairo")
+        const gtk_libname = unsafe_wrap(Vector{UInt8}, "julia_gtk:cairo")
+        const gtk_device = 
         [ 
-          gvplugin_installed_t(Int32(0),pointer(generic_cairo_name), Int32(0), pointer(generic_cairo_engine), pointer(generic_cairo_features));
+          gvplugin_installed_t(Int32(0),pointer(gtk_name), Int32(0), pointer(gtk_engine), pointer(gtk_features));
           null(gvplugin_installed_t)
         ]
-        const generic_cairo_api = 
+        const gtk_api = 
         [
-            gvplugin_api_t(API_device, pointer(generic_cairo_device))
+            gvplugin_api_t(API_device, pointer(gtk_device))
             null(gvplugin_api_t)
         ]
 
-        add_julia_cairo!(c::Context) = ccall((:gvAddLibrary,gvc),Void,(Ptr{Void},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(generic_cairo_libname),pointer(generic_cairo_api))])
+        add_julia_gtk!(c::Context) = ccall((:gvAddLibrary,gvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(gtk_libname),pointer(gtk_api))])
 
-        function render(c::CairoContext,g::GraphViz.Graph; context = default_context, format="julia:cairo")
-            GraphViz.add_julia_cairo!(context)
-            if !g.didlayout
-                error("Must call layout before calling render!")
+        function render(c::Gtk.Canvas,cg::Context,g::Graph) 
+            @async begin
+                add_julia_gtk!(cg)
+                ccall((:gvRenderContext,gvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),cg.handle,g.handle,"julia_gtk",c)    
             end
-            ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8},Any),context.handle,g.handle,format,c)
+            nothing
         end
-
-        function cairo_render(g::GraphViz.Graph; context = default_context, format="julia:cairo")
-            global last_surface
-            GraphViz.add_julia_cairo!(context)
-            if !g.didlayout
-                error("Must call layout before calling render!")
-            end
-            ccall((:gvRenderContext,GraphViz.gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8},Ptr{Void}),context.handle,g.handle,format,C_NULL)
-            surface = last_surface
-            last_surface = nothing
-            return surface
-        end
-
-        function Base.show(io::IO, m::MIME"image/png", x::Graph)
-            if !x.didlayout
-                layout!(x,engine="dot")
-            end
-            show(io, m, cairo_render(x))
-        end
-        #=
-        if isdir(Pkg.dir("Gtk"))
-            using Gtk
-
-            function gtk_initialize(firstjob::Ptr{Void})
-                firstjob = convert(Ptr{GVJ_s},firstjob)
-                job = unsafe_load(firstjob)
-                c = unsafe_pointer_to_objref(job.context)::Gtk.Canvas
-                c.data = firstjob
-                job.context = getgc(c).ptr
-                job.window = pointer_from_objref(c)
-                unsafe_store!(firstjob,job)
-                nothing
-            end
-
-            function gtk_finalize(firstjob::Ptr{Void})
-                firstjob = convert(Ptr{GVJ_s},firstjob)
-                job = unsafe_load(firstjob)
-                c = unsafe_pointer_to_objref(job.window)::Gtk.Canvas
-                draw(gtk_update,c)
-                wait() #TODO: Make conditional on closing the widget
-                nothing
-            end 
-
-            function gtk_update(c::Canvas)
-                jobp = c.data::Ptr{GVJ_s}
-                job = unsafe_load(jobp)
-                job.height              = height(c)
-                job.width               = width(c)
-                job.context             = getgc(c).ptr
-                job.external_context    = 0x1
-                unsafe_store!(jobp,job)
-                println(job.callbacks)
-                println(unsafe_load(job.callbacks).refresh)
-                ccall(unsafe_load(job.callbacks).refresh,Void,(Ptr{Void},),jobp)
-            end
-            const gtk_engine = [ gvdevice_engine_t(cfunction(gtk_initialize,Void,(Ptr{Void},)),C_NULL,cfunction(gtk_finalize,Void,(Ptr{Void},))) ]
-            const gtk_features = [ gvdevice_features_t(Int32(GVDEVICE_EVENTS),0.,0.,0.,0.,96.,96.) ]
-            const gtk_name = Vector{UInt8}("julia_gtk:cairo")
-            const gtk_libname = Vector{UInt8}("julia_gtk:cairo")
-            const gtk_device = 
-            [ 
-              gvplugin_installed_t(Int32(0),pointer(gtk_name), Int32(0), pointer(gtk_engine), pointer(gtk_features));
-              null(gvplugin_installed_t)
-            ]
-            const gtk_api = 
-            [
-                gvplugin_api_t(API_device, pointer(gtk_device))
-                null(gvplugin_api_t)
-            ]
-
-            add_julia_gtk!(c::Context) = ccall((:gvAddLibrary,gvc),Void,(Ptr{Void},Ptr{gvplugin_library_t}),c.handle,[gvplugin_library_t(pointer(gtk_libname),pointer(gtk_api))])
-
-            function render(c::Gtk.Canvas,cg::Context,g::Graph) 
-                @async begin
-                    add_julia_gtk!(cg)
-                    ccall((:gvRenderContext,gvc),Cint,(Ptr{Void},Ptr{Void},Ptr{UInt8},Any),cg.handle,g.handle,"julia_gtk",c)    
-                end
-                nothing
-            end
-        end
-        =#
     end
+    =#
 
-    graph_plugins(c::Context) = Graph(ccall((:gvPluginsGraph,gvc),Ptr{Void},(Ptr{Void},),c.handle))
+    graph_plugins(c::Context) = Graph(ccall((:gvPluginsGraph,gvc),Ptr{Cvoid},(Ptr{Cvoid},),c.handle))
 
     function listPlugins(c,kind)
         s = Array(Cint,1)
-        r = ccall((:gvPluginList,gvc),Ptr{Ptr{UInt8}},(Ptr{Void},Ptr{UInt8},Ptr{Cint},Ptr{UInt8}),c.handle,kind,s,C_NULL)
+        r = ccall((:gvPluginList,gvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Ptr{UInt8},Ptr{Cint},Ptr{UInt8}),c.handle,kind,s,C_NULL)
         if r == C_NULL
             error("No Plugins available")
         end


### PR DESCRIPTION
**Do not merge**. This PR is a start towards porting the library to Julia v0.7/v1.0. It's not working yet.

I get a segfault when trying to create a simple graph. I can't go down this rabbit hole right now but perhaps someone more knowledgeable can help move this forward.

```
julia> Graph("digraph G { n1 -> n2; }")
Process 32584 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x11b858000)
    frame #0: 0x000000011b858000
->  0x11b858000: xlatb
    0x11b858001: addb   %al, (%rax)
    0x11b858003: addb   %al, (%rax,%rax)
    0x11b858006: addb   %al, (%rax)
Target 0: (julia) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x11b858000)
  * frame #0: 0x000000011b858000
    frame #1: 0x000000011bf22f81 libcgraph.dylib`aaglex + 1232
    frame #2: 0x000000011bf1f40e libcgraph.dylib`aagparse + 154
    frame #3: 0x000000011bf202a3 libcgraph.dylib`agconcat + 67
    frame #4: 0x000000011b767766
    frame #5: 0x00000001002b3a78 libjulia.dylib`do_call + 200
    frame #6: 0x00000001002b253c libjulia.dylib`eval_body + 1228
    frame #7: 0x00000001002b2a88 libjulia.dylib`jl_interpret_toplevel_thunk_callback + 408
    frame #8: 0x000000010010657c libjulia.dylib`enter_interpreter_frame + 28
    frame #9: 0x00000001002b2ae0 libjulia.dylib`jl_interpret_toplevel_thunk + 32
    frame #10: 0x0000000100120749 libjulia.dylib`jl_toplevel_eval_flex + 1993
    frame #11: 0x0000000100100882 libjulia.dylib`jl_toplevel_eval_in + 530
    frame #12: 0x0000000104eaa542 sys.dylib`japi1_eval_3982 at boot.jl:319 [opt]
    frame #13: 0x00000001055161c6 sys.dylib`japi1_eval_user_input_9798 at REPL.jl:85 [opt]
    frame #14: 0x0000000105516414 sys.dylib`japi1_#28_9796 [inlined] macro expansion at REPL.jl:117 [opt]
    frame #15: 0x00000001055163f0 sys.dylib`japi1_#28_9796 at task.jl:262 [opt]
    frame #16: 0x000000010010ab70 libjulia.dylib`start_task + 352
```