### PR TITLE
Add engine attribute to Graph, and default to 'dot' layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ graph graphname {
  }
 """
 ```
+
+# Advanced Examples
+
+The default [layout](https://graphviz.org/docs/layouts/) used in this package in `dot`.
+To change the layout, you can access the `engine` attribute of the Graph **before** showing it, or using the constructor `GraphViz.Graph` with the additional keyword attribute `engine=...`.
+
+```
+G = GraphViz.Graph("""
+digraph graphname {
+    rankdir="LR";
+    x [label="{x = 3.0 | ∂x = 2.0 }", shape=record];
+    y [label="{y = 2.0 | ∂y = 3.0 }", shape=record];
+    z [label="{z = 6.0 | ∂z = 1.0 }", shape=record];
+    "z*" [label="*"];
+    x -> "z*";
+    y -> "z*";
+    "z*" -> z;
+}
+""", engine="dot")
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,29 @@
 using GraphViz, Cairo, Test
 
-let g = dot"""
-graph graphname {
-     // The label attribute can be used to change the label of a node
-     a [label="Foo"];
-     // Here, the node shape is changed.
-     b [shape=box];
-     // These edges both have different line properties
-     a -- b -- c [color=blue];
-     b -- d [style=dotted];
- }
-"""
+@testset "Basic tests" begin
+    g = dot"""graph graphname {
+        a [label="Foo"];
+        b [shape=box];
+        a -- b -- c [color=blue];
+        b -- d [style=dotted];
+    }"""
     @test_nowarn show(IOBuffer(), MIME"image/svg+xml"(), g)
     @test_nowarn show(IOBuffer(), MIME"image/png"(), g)
-end
 
+    dot_example = """graph graphname {
+        a [label="Foo"];
+        b [shape=box];
+        a -- b -- c [color=blue];
+        b -- d [style=dotted];
+    }"""
+
+    g = GraphViz.Graph(dot_example)
+    @test_nowarn show(IOBuffer(), MIME"image/svg+xml"(), g)
+    @test_nowarn show(IOBuffer(), MIME"image/png"(), g)
+
+    @testset "Engine $engine" for engine in ["dot", "neato", "fdp", "circo", "twopi", "osage", "patchwork"]
+        g = GraphViz.Graph(dot_example, engine=engine)
+        @test_nowarn show(IOBuffer(), MIME"image/svg+xml"(), g)
+        @test_nowarn show(IOBuffer(), MIME"image/png"(), g)
+    end
+end


### PR DESCRIPTION
On #38, we noticed that some position-related attributes are not working (e.g., rankdir). Apparently, the code is using the layout "neato", and the layout that we want to use is "dot".

I've added a field to `Graph` to allow changing the engine. I don't know the details on GraphViz, so I am not sure how adequate the implementation is.
I also changed the default to "dot", but I can change it if desired.

I have created a test and an example on the README.