### PR TITLE
Fix `NUL` terminator + `Cstring` usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -191,17 +191,18 @@ module GraphViz
     graph_plugins(c::Context) = Graph(ccall((:gvPluginsGraph,libgvc),Ptr{Cvoid},(Ptr{Cvoid},),c.handle))
 
     function listPlugins(c,kind)
-        s = Array(Cint,1)
-        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Ptr{UInt8},Ptr{Cint},Ptr{UInt8}),c.handle,kind,s,C_NULL)
+        s = Ref{Cint}()
+        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Cstring,Ptr{Cint},Cstring),c.handle,kind,s,C_NULL)
         if r == C_NULL
             error("No Plugins available")
         end
-        ret = Array(ByteString,s[1])
-        for i = 1:s[1]
-            ret[i] = bytestring(unsafe_load(r,i))
-            c_free(unsafe_load(r,i))
+        ret = Vector{String}(undef, s[])
+        for i = 1:s[]
+            p = unsafe_load(r,i)
+            ret[i] = unsafe_string(p)
+            Libc.free(p)
         end
-        c_free(r)
+        Libc.free(r)
         ret
     end
 

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -9,20 +9,21 @@ module GraphViz
 
     function jl_afread(io::IO, buf::Ptr{UInt8}, bufsize::Cint)
         #@show (io,buf,bufsize)
-        ret = readbytes!(io,unsafe_wrap(Array,buf,Int(bufsize)))
-        #@show ret
-        convert(Cint,ret)
+        nbytes = readbytes!(io, unsafe_wrap(Array, buf, Int(bufsize)))
+        #@show nbytes
+        convert(Cint, nbytes)
     end
 
-    function jl_putstr(io::IO, str::Ptr{UInt8})
-        #@show (io,str)
-        convert(Cint,write(io,unsafe_wrap(Array,str,Int(ccall(:strlen,Csize_t,(Ptr{UInt8},),str)))))::Cint
+    function jl_putstr(io::IO, str::Cstring)
+        #@show (io, str)
+        nbytes = write(io, unsafe_string(str))
+        convert(Cint, nbytes)
     end
 
     jl_flush(io::IO) = convert(Cint,0)
 
 
-    null(::Type{gvplugin_installed_t}) = gvplugin_installed_t(Int32(0),convert(Ptr{UInt8},0),
+    null(::Type{gvplugin_installed_t}) = gvplugin_installed_t(Int32(0),Cstring(C_NULL),
         Int32(0),convert(Ptr{gvdevice_engine_t},0),convert(Ptr{gvdevice_features_t},0))
     null(::Type{gvplugin_api_t}) = gvplugin_api_t(Int32(0),convert(Ptr{gvplugin_installed_t},0))
 
@@ -76,7 +77,7 @@ module GraphViz
     function Graph(graph::IO)
         iodisc = Ref(Agiodisc_s(
             @cfunction(jl_afread,Cint,(Any,Ptr{UInt8},Cint)),
-            @cfunction(jl_putstr,Cint,(Any,Ptr{UInt8})),
+            @cfunction(jl_putstr,Cint,(Any,Cstring)),
             @cfunction(jl_flush,Cint,(Any,))))
         discs = Ref(Agdisc_s(cglobal((:AgMemDisc,libcgraph)),
             cglobal((:AgIdDisc,libcgraph)),
@@ -91,12 +92,12 @@ module GraphViz
 
     function layout!(g::Graph;engine="neato", context = default_context[])
         @assert g.handle != C_NULL
-        if ccall((:gvLayout,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8}),context.handle,g.handle,engine) == 0
+        if ccall((:gvLayout,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring),context.handle,g.handle,engine) == 0
             g.didlayout = true
         end
     end
 
-    render_x11(c::Context,g::Graph) = ccall((:gvRender,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),c.handle,g.handle,"x11",C_NULL)
+    render_x11(c::Context,g::Graph) = ccall((:gvRender,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Ptr{Cvoid}),c.handle,g.handle,"x11",C_NULL)
     render_jobs(c::Context,g::Graph) = ccall((:gvRenderJobs,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid}),c.handle,g.handle)
 
     # Render
@@ -148,15 +149,15 @@ module GraphViz
 
     const julia_io_engine = Ref{gvdevice_engine_t}()
     const julia_io_features = Ref{gvdevice_features_t}(gvdevice_features_t(Int32(GVDEVICE_DOES_TRUECOLOR|GVDEVICE_DOES_LAYERS),0.,0.,0.,0.,72.,72.))
-    const julia_io_name = Vector{UInt8}("julia_io:svg")
-    const julia_io_libname = Vector{UInt8}("julia_io")
+    const julia_io_name = "julia_io:svg" # must be global to remain rooted for GC
+    const julia_io_libname = "julia_io" # must be global to remain rooted for GC
     const julia_io_device = Ref{NTuple{2, gvplugin_installed_t}}()
     const julia_io_api = Ref{NTuple{2, gvplugin_api_t}}()
 
     function init_io_structs!()
         julia_io_engine[] = gvdevice_engine_t(@cfunction(julia_io_initialize,Cvoid,(Ptr{Cvoid},)),C_NULL,@cfunction(julia_io_finalize,Cvoid,(Ptr{Cvoid},)))
         julia_io_device[] = (
-            gvplugin_installed_t(Int32(0),pointer(julia_io_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_io_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_io_features)),
+            gvplugin_installed_t(Int32(0), unsafe_convert(Cstring, julia_io_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_io_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_io_features)),
             null(gvplugin_installed_t)
         )
         julia_io_api[] = (gvplugin_api_t(API_device, unsafe_convert(Ptr{gvplugin_installed_t}, julia_io_device)),
@@ -165,7 +166,9 @@ module GraphViz
 
     function add_julia_io!(c::Context)
         lib = Ref{gvplugin_library_t}(gvplugin_library_t(
-            pointer(julia_io_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_io_api)))
+            unsafe_convert(Cstring, julia_io_libname),
+            unsafe_convert(Ptr{gvplugin_api_t}, julia_io_api)
+        ))
         ccall((:gvAddLibrary,libgvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,lib)
     end
 
@@ -175,7 +178,7 @@ module GraphViz
         end
         state = IODeviceState(io,C_NULL)
         active_devices[state] = state
-        ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,state)
+        ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Any),context.handle,g.handle,format,state)
     end
 
     function Base.show(io::IO, ::MIME"image/svg+xml", x::Graph)

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -45,15 +45,15 @@ end
 
 const julia_cairo_engine = Ref{gvdevice_engine_t}()
 const julia_cairo_features = Ref{gvdevice_features_t}(gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.))
-const julia_cairo_name = Vector{UInt8}("julia:cairo")
-const julia_cairo_libname = Vector{UInt8}("julia:cairo")
+const julia_cairo_name = "julia:cairo" # must be global to remain rooted for GC
+const julia_cairo_libname = "julia:cairo" # must be global to remain rooted for GC
 const julia_cairo_device = Ref{NTuple{2, gvplugin_installed_t}}()
 const julia_cairo_api = Ref{NTuple{2, gvplugin_api_t}}()
 
 function init_cairo_structs!()
     julia_cairo_engine[] = gvdevice_engine_t(@cfunction(cairo_initialize,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_format,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_finalize,Cvoid,(Ptr{Cvoid},)))
     julia_cairo_device[] = (
-        gvplugin_installed_t(Int32(0),pointer(julia_cairo_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_cairo_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_cairo_features)),
+        gvplugin_installed_t(Int32(0), unsafe_convert(Cstring, julia_cairo_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_cairo_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_cairo_features)),
         null(gvplugin_installed_t)
     )
     julia_cairo_api[] = (gvplugin_api_t(API_device, unsafe_convert(Ptr{gvplugin_installed_t}, julia_cairo_device)),
@@ -62,7 +62,7 @@ end
 
 function add_julia_cairo!(c::Context)
     lib = Ref{gvplugin_library_t}(gvplugin_library_t(
-        pointer(julia_cairo_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_cairo_api)))
+        unsafe_convert(Cstring, julia_cairo_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_cairo_api)))
     ccall((:gvAddLibrary,libgvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,lib)
 end
 
@@ -76,7 +76,7 @@ function render(c::CairoContext,g::GraphViz.Graph; context = default_context[], 
     if !g.didlayout
         error("Must call layout before calling render!")
     end
-    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,c)
+    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Any),context.handle,g.handle,format,c)
 end
 
 function cairo_render(g::GraphViz.Graph; context = default_context[], format="julia:cairo")
@@ -85,7 +85,7 @@ function cairo_render(g::GraphViz.Graph; context = default_context[], format="ju
     if !g.didlayout
         error("Must call layout before calling render!")
     end
-    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),context.handle,g.handle,format,C_NULL)
+    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Ptr{Cvoid}),context.handle,g.handle,format,C_NULL)
     surface = last_surface
     last_surface = nothing
     return surface

--- a/src/capi.jl
+++ b/src/capi.jl
@@ -22,7 +22,7 @@ end
 
 struct gvplugin_installed_t
     id::Cint
-    ctype::Ptr{UInt8}
+    ctype::Cstring
     quality::Cint
     engine::Ptr{gvdevice_engine_t}
     features::Ptr{gvdevice_features_t}
@@ -70,7 +70,7 @@ struct gvplugin_api_t
 end
 
 struct gvplugin_library_t
-    name::Ptr{UInt8}
+    name::Cstring
     apis::Ptr{gvplugin_api_t}
 end
 
@@ -80,24 +80,24 @@ struct gvplugin_active_device_t
     engine::Ptr{gvdevice_engine_t}
     id::Cint
     features::Ptr{gvdevice_features_t}
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gvplugin_active_render_t
     engine::Ptr{Cvoid}
     id::Cint
     features::Ptr{Cvoid}
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gvplugin_active_loadimage_t
     engine::Ptr{Cvoid}
     id::Cint
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gv_argvlist_t
-    argv::Ptr{Ptr{UInt8}}
+    argv::Ptr{Cstring}
     argc::Cint;
     alloc::Cint;
 end
@@ -126,8 +126,8 @@ end
 
 # TODO: These are probably wrong
 mutable struct GVCOMMON_s
-    info::Ptr{Ptr{UInt8}}
-    cmdname::Ptr{UInt8}
+    info::Ptr{Cstring}
+    cmdname::Cstring
     verbose::Cint
     config::UInt8
     auto_outfile_names::UInt8
@@ -142,10 +142,10 @@ end
 mutable struct GVC_s
     common::GVCOMMON_s
 
-    config_path::Ptr{UInt8}
+    config_path::Cstring
     config_found::UInt8
 
-    input_filenames::Ptr{Ptr{UInt8}}
+    input_filenames::Ptr{Cstring}
 
     gvgs::Ptr{Cvoid}
     gvg::Ptr{Cvoid}
@@ -177,18 +177,18 @@ mutable struct GVJ_s
     common::Ptr{Cvoid}
 
     obj_state::Ptr{Cvoid}
-    input_filename::Ptr{UInt8}
+    input_filename::Cstring
     graph_index::Cint
 
-    layout_type::Ptr{UInt8}
+    layout_type::Cstring
 
-    output_filename::Ptr{UInt8}
+    output_filename::Cstring
     output_file::Ptr{Cvoid}
     output_data::Ptr{UInt8}
     output_data_allocated::Cuint
     output_data_position::Cuint
 
-    output_langname::Ptr{UInt8}
+    output_langname::Cstring
     output_lang::Ptr{Cint}
 
     render::gvplugin_active_render_t
@@ -259,8 +259,8 @@ mutable struct GVJ_s
     current_obj::Ptr{Cvoid}
     selected_obj::Ptr{Cvoid}
 
-    active_tooltip::Ptr{UInt8}
-    selected_href::Ptr{UInt8}
+    active_tooltip::Cstring
+    selected_href::Cstring
 
     selected_obj_type_name::gv_argvlist_t
     selected_obj_attributes::gv_argvlist_t

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,3 +15,13 @@ graph graphname {
     @test_nowarn show(IOBuffer(), MIME"image/png"(), g)
 end
 
+@testset "listPlugins" begin
+    ctx = GraphViz.default_context[]
+    layouts = GraphViz.listPlugins(ctx, "layout")
+    @test layouts isa Vector{String}
+    @test "dot" in layouts
+    @test "neato" in layouts
+    # gvPluginList returns NULL for an unrecognized api kind
+    @test_throws ErrorException GraphViz.listPlugins(ctx, "nosuchapi")
+end
+


### PR DESCRIPTION
Only the changes to the `const`s are strictly necessary, but the other `Ptr{UInt8}` -> `Cstring` changes are included for hygiene. Also includes a drive-by fix to `listPlugins` since it was clearly in need of some support.

Resolves #56 / #45. Supersedes #49  / #46.

Done by hand and reviewed by Claude.