### PR TITLE
Update `GraphViz_jll` v2 → v15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          - version: '1'
+            os: macos-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,258 +1,263 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.0-DEV.621"
+julia_version = "1.11.6"
 manifest_format = "2.0"
+project_hash = "f2ba0eb1c0a079c0ad5fd35eb94e5b9b8cb051a3"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.Bzip2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1b96ea4a01afe0ea4090c5c8039690672dd13f2e"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.8+0"
+version = "1.0.9+0"
 
 [[deps.Cairo_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "f2202b55d816427cd385a9a4f3ffb226bee80f99"
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "1fa950ebc3e37eccd51c6a8fe1f92f7d86263522"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
-version = "1.16.1+0"
+version = "1.18.7+0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.0+0"
+version = "1.1.1+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.5.1"
+version = "1.6.0"
 
 [[deps.Expat_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e6c4a6407a949e79a9d3f249bf49e6987c80e01f"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.2.10+0"
+version = "2.8.2+0"
 
 [[deps.FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "2db648b6712831ecb333eae76dbfd1c156ca13bb"
+git-tree-sha1 = "6621fef488e496356c9c9625d0562c12a6070819"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.11.2"
+version = "1.20.0"
+
+    [deps.FileIO.extensions]
+    HTTPExt = "HTTP"
+
+    [deps.FileIO.weakdeps]
+    HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.Fontconfig_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "21efd19106a55620a188615da6d3d06cd7f6ee03"
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Zlib_jll"]
+git-tree-sha1 = "f85dac9a96a01087df6e3a749840015a0ca3817d"
 uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
-version = "2.13.93+0"
+version = "2.17.1+0"
 
 [[deps.FreeType2_jll]]
-deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "87eb71354d8ec1a96d4a7636bd57a7347dde3ef9"
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "70329abc09b886fd2c5d94ad2d9527639c421e3e"
 uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
-version = "2.10.4+0"
+version = "2.14.3+1"
 
 [[deps.FriBidi_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7a214fdac5ed5f59a22c2d9a885a16da1c74bbc7"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
-version = "1.0.10+0"
+version = "1.0.17+0"
 
-[[deps.Gettext_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
-git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
-uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
-version = "0.21.0+0"
+[[deps.GettextRuntime_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll"]
+git-tree-sha1 = "45288942190db7c5f760f59c04495064eedf9340"
+uuid = "b0724c58-0f36-5564-988d-3bb0596ebc4a"
+version = "0.22.4+0"
 
 [[deps.Glib_jll]]
-deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "7bf67e9a481712b3dbe9cb3dac852dc4b1162e02"
+deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.68.3+0"
+version = "2.86.3+0"
 
 [[deps.Graphite2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "344bf40dcab1073aca04aa0df4fb092f920e4011"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "69ffb934a5c5b7e086a0b4fee3427db2556fba6e"
 uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
-version = "1.3.14+0"
+version = "1.3.16+0"
 
 [[deps.Graphviz_jll]]
-deps = ["Artifacts", "Cairo_jll", "Expat_jll", "JLLWrappers", "Libdl", "Pango_jll", "Pkg"]
-git-tree-sha1 = "cb399bbf057084282d7036312b1dc7a0eb103bf4"
+deps = ["Artifacts", "Cairo_jll", "Expat_jll", "JLLWrappers", "Libdl", "Pango_jll", "Zlib_jll"]
+git-tree-sha1 = "c2b4dd5cf7f6a5c2f9144a8a9f115800eba1c9cf"
 uuid = "3c863552-8265-54e4-a6dc-903eb78fde85"
-version = "2.49.3+1"
+version = "15.1.0+0"
 
 [[deps.HarfBuzz_jll]]
-deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
-git-tree-sha1 = "8a954fed8ac097d5be04921d595f741115c1b2ad"
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "2.8.1+0"
-
-[[deps.InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "8.5.1+0"
 
 [[deps.JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.3.0"
+version = "1.8.0"
 
-[[deps.LZO_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e5b909bcf985c5e2605737d2ce278ed791b89be6"
-uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
-version = "2.10.1+0"
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b7970cef8ae1c990ba0c09cd8bdc1145e006632f"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "22.1.7+0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.73.0+4"
+version = "8.6.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.9.1+2"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Libffi_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0b4a5d71f3e5200a7dff793393e09dfc2d874290"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c8da7e6a91781c41a863611c7e966098d783c57a"
 uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
-version = "3.2.2+1"
-
-[[deps.Libgcrypt_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
-git-tree-sha1 = "64613c82a59c120435c067c2b809fc61cf5166ae"
-uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
-version = "1.8.7+0"
-
-[[deps.Libgpg_error_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c333716e46366857753e273ce6a69ee0945a6db9"
-uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
-version = "1.42.0+0"
+version = "3.4.7+0"
 
 [[deps.Libiconv_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.18.0+0"
 
 [[deps.Libmount_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9c30530bf0effd46e15e0fdcf2b8636e78cbbd73"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cc3ad4faf30015a3e8094c9b5b7f19e85bdf2386"
 uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
-version = "2.35.0+0"
+version = "2.42.0+0"
 
 [[deps.Libuuid_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "7f3efec06033682db852f8b3bc3c1d2b0a0ab066"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d620582b1f0cbe2c72dd1d5bd195a9ce73370ab1"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
-version = "2.36.0+0"
+version = "2.42.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.24.0+2"
+version = "2.28.6+0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2020.7.22"
+version = "2023.12.12"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[deps.PCRE_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b2a7af664e098055a7529ad1a900ded962bca488"
-uuid = "2f80f16e-611a-54ab-bc61-aa92de5b98fc"
-version = "8.44.0+0"
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.42.0+1"
 
 [[deps.Pango_jll]]
-deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9bc1871464b12ed19297fbc56c4fb4ba84988b0d"
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.47.0+0"
+version = "1.57.1+0"
 
 [[deps.Pixman_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b4f5d02549a10e20780a24fce72bea96b6329e29"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
+git-tree-sha1 = "e4a6721aa89e62e5d4217c0b21bd714263779dda"
 uuid = "30392449-352a-5448-841d-b1acce4e97dc"
-version = "0.40.1+0"
+version = "0.46.4+0"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+version = "1.11.0"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
-[[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.3.1"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-
-[[deps.Serialization]]
-uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[deps.Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "0.7.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -262,87 +267,71 @@ version = "1.10.0"
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[deps.XML2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
-uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
-
-[[deps.XSLT_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]
-git-tree-sha1 = "91844873c4085240b95e795f692c4cec4d805f8a"
-uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
-version = "1.1.34+0"
+version = "1.11.0"
 
 [[deps.Xorg_libX11_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
-git-tree-sha1 = "5be649d550f3f4b95308bf0183b82e2582876527"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "808090ede1d41644447dd5cbafced4731c56bd2f"
 uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
-version = "1.6.9+4"
+version = "1.8.13+0"
 
 [[deps.Xorg_libXau_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4e490d5c960c314f33885790ed410ff3a94ce67e"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "aa1261ebbac3ccc8d16558ae6799524c450ed16b"
 uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
-version = "1.0.9+4"
+version = "1.0.13+0"
 
 [[deps.Xorg_libXdmcp_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4fe47bd2247248125c428978740e18a681372dd4"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "52858d64353db33a56e13c341d7bf44cd0d7b309"
 uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
-version = "1.1.3+4"
+version = "1.1.6+0"
 
 [[deps.Xorg_libXext_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
-git-tree-sha1 = "b7c0aa8c376b31e4852b360222848637f481f8c3"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "1a4a26870bf1e5d26cd585e38038d399d7e65706"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
-version = "1.3.4+4"
+version = "1.3.8+0"
 
 [[deps.Xorg_libXrender_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
-git-tree-sha1 = "19560f30fd49f4d4efbe7002a1037f8c43d43b96"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
 uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
-version = "0.9.10+4"
-
-[[deps.Xorg_libpthread_stubs_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "6783737e45d3c59a4a4c4091f5f88cdcf0908cbb"
-uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
-version = "0.1.0+3"
+version = "0.9.12+0"
 
 [[deps.Xorg_libxcb_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
-git-tree-sha1 = "daf17f441228e7a3833846cd048892861cff16d6"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
+git-tree-sha1 = "bfcaf7ec088eaba362093393fe11aa141fa15422"
 uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
-version = "1.13.0+3"
+version = "1.17.1+0"
 
 [[deps.Xorg_xtrans_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "79c31e7844f6ecf779705fbc12146eb190b7d845"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a63799ff68005991f9d9491b6e95bd3478d783cb"
 uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
-version = "1.4.0+3"
+version = "1.6.0+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+1"
+version = "1.2.13+1"
 
 [[deps.libpng_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "94d180a6d2b5e55e447e2d27a29ed04fe79eb30c"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "e51150d5ab85cee6fc36726850f0e627ad2e4aba"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.38+0"
+version = "1.6.58+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.41.0+1"
+version = "1.59.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "16.2.1+1"
+version = "17.4.0+2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphViz"
 uuid = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -8,7 +8,7 @@ Graphviz_jll = "3c863552-8265-54e4-a6dc-903eb78fde85"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-Graphviz_jll = "2.49.3 - 2"
+Graphviz_jll = "15"
 julia = "1"
 FileIO = "1"
 Requires = "1"

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -191,17 +191,18 @@ module GraphViz
     graph_plugins(c::Context) = Graph(ccall((:gvPluginsGraph,libgvc),Ptr{Cvoid},(Ptr{Cvoid},),c.handle))
 
     function listPlugins(c,kind)
-        s = Array(Cint,1)
-        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Ptr{UInt8},Ptr{Cint},Ptr{UInt8}),c.handle,kind,s,C_NULL)
+        s = Ref{Cint}()
+        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Cstring,Ptr{Cint},Cstring),c.handle,kind,s,C_NULL)
         if r == C_NULL
             error("No Plugins available")
         end
-        ret = Array(ByteString,s[1])
-        for i = 1:s[1]
-            ret[i] = bytestring(unsafe_load(r,i))
-            c_free(unsafe_load(r,i))
+        ret = Vector{String}(undef, s[])
+        for i = 1:s[]
+            p = unsafe_load(r,i)
+            ret[i] = unsafe_string(p)
+            Libc.free(p)
         end
-        c_free(r)
+        Libc.free(r)
         ret
     end
 

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -9,20 +9,21 @@ module GraphViz
 
     function jl_afread(io::IO, buf::Ptr{UInt8}, bufsize::Cint)
         #@show (io,buf,bufsize)
-        ret = readbytes!(io,unsafe_wrap(Array,buf,Int(bufsize)))
-        #@show ret
-        convert(Cint,ret)
+        nbytes = readbytes!(io, unsafe_wrap(Array, buf, Int(bufsize)))
+        #@show nbytes
+        convert(Cint, nbytes)
     end
 
-    function jl_putstr(io::IO, str::Ptr{UInt8})
-        #@show (io,str)
-        convert(Cint,write(io,unsafe_wrap(Array,str,Int(ccall(:strlen,Csize_t,(Ptr{UInt8},),str)))))::Cint
+    function jl_putstr(io::IO, str::Cstring)
+        #@show (io, str)
+        nbytes = write(io, unsafe_string(str))
+        convert(Cint, nbytes)
     end
 
     jl_flush(io::IO) = convert(Cint,0)
 
 
-    null(::Type{gvplugin_installed_t}) = gvplugin_installed_t(Int32(0),convert(Ptr{UInt8},0),
+    null(::Type{gvplugin_installed_t}) = gvplugin_installed_t(Int32(0),Cstring(C_NULL),
         Int32(0),convert(Ptr{gvdevice_engine_t},0),convert(Ptr{gvdevice_features_t},0))
     null(::Type{gvplugin_api_t}) = gvplugin_api_t(Int32(0),convert(Ptr{gvplugin_installed_t},0))
 
@@ -76,7 +77,7 @@ module GraphViz
     function Graph(graph::IO)
         iodisc = Ref(Agiodisc_s(
             @cfunction(jl_afread,Cint,(Any,Ptr{UInt8},Cint)),
-            @cfunction(jl_putstr,Cint,(Any,Ptr{UInt8})),
+            @cfunction(jl_putstr,Cint,(Any,Cstring)),
             @cfunction(jl_flush,Cint,(Any,))))
         discs = Ref(Agdisc_s(cglobal((:AgMemDisc,libcgraph)),
             cglobal((:AgIdDisc,libcgraph)),
@@ -91,12 +92,12 @@ module GraphViz
 
     function layout!(g::Graph;engine="neato", context = default_context[])
         @assert g.handle != C_NULL
-        if ccall((:gvLayout,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8}),context.handle,g.handle,engine) == 0
+        if ccall((:gvLayout,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring),context.handle,g.handle,engine) == 0
             g.didlayout = true
         end
     end
 
-    render_x11(c::Context,g::Graph) = ccall((:gvRender,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),c.handle,g.handle,"x11",C_NULL)
+    render_x11(c::Context,g::Graph) = ccall((:gvRender,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Ptr{Cvoid}),c.handle,g.handle,"x11",C_NULL)
     render_jobs(c::Context,g::Graph) = ccall((:gvRenderJobs,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid}),c.handle,g.handle)
 
     # Render
@@ -148,15 +149,15 @@ module GraphViz
 
     const julia_io_engine = Ref{gvdevice_engine_t}()
     const julia_io_features = Ref{gvdevice_features_t}(gvdevice_features_t(Int32(GVDEVICE_DOES_TRUECOLOR|GVDEVICE_DOES_LAYERS),0.,0.,0.,0.,72.,72.))
-    const julia_io_name = Vector{UInt8}("julia_io:svg")
-    const julia_io_libname = Vector{UInt8}("julia_io")
+    const julia_io_name = "julia_io:svg" # must be global to remain rooted for GC
+    const julia_io_libname = "julia_io" # must be global to remain rooted for GC
     const julia_io_device = Ref{NTuple{2, gvplugin_installed_t}}()
     const julia_io_api = Ref{NTuple{2, gvplugin_api_t}}()
 
     function init_io_structs!()
         julia_io_engine[] = gvdevice_engine_t(@cfunction(julia_io_initialize,Cvoid,(Ptr{Cvoid},)),C_NULL,@cfunction(julia_io_finalize,Cvoid,(Ptr{Cvoid},)))
         julia_io_device[] = (
-            gvplugin_installed_t(Int32(0),pointer(julia_io_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_io_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_io_features)),
+            gvplugin_installed_t(Int32(0), unsafe_convert(Cstring, julia_io_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_io_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_io_features)),
             null(gvplugin_installed_t)
         )
         julia_io_api[] = (gvplugin_api_t(API_device, unsafe_convert(Ptr{gvplugin_installed_t}, julia_io_device)),
@@ -165,7 +166,9 @@ module GraphViz
 
     function add_julia_io!(c::Context)
         lib = Ref{gvplugin_library_t}(gvplugin_library_t(
-            pointer(julia_io_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_io_api)))
+            unsafe_convert(Cstring, julia_io_libname),
+            unsafe_convert(Ptr{gvplugin_api_t}, julia_io_api)
+        ))
         ccall((:gvAddLibrary,libgvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,lib)
     end
 
@@ -175,7 +178,7 @@ module GraphViz
         end
         state = IODeviceState(io,C_NULL)
         active_devices[state] = state
-        ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,state)
+        ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Any),context.handle,g.handle,format,state)
     end
 
     function Base.show(io::IO, ::MIME"image/svg+xml", x::Graph)

--- a/src/GraphViz.jl
+++ b/src/GraphViz.jl
@@ -79,8 +79,7 @@ module GraphViz
             @cfunction(jl_afread,Cint,(Any,Ptr{UInt8},Cint)),
             @cfunction(jl_putstr,Cint,(Any,Cstring)),
             @cfunction(jl_flush,Cint,(Any,))))
-        discs = Ref(Agdisc_s(cglobal((:AgMemDisc,libcgraph)),
-            cglobal((:AgIdDisc,libcgraph)),
+        discs = Ref(Agdisc_s(cglobal((:AgIdDisc,libcgraph)),
             Base.unsafe_convert(Ptr{Agiodisc_s}, iodisc)))
         Graph(@GC.preserve iodisc ccall((:agread,libcgraph),Ptr{Cvoid},(Any,Ptr{Cvoid}),graph,discs))
     end
@@ -118,8 +117,7 @@ module GraphViz
         len #Julia doesn't do half things :)
     end
 
-    # determined by counting bytes ;)
-    const WRITEFN_OFFSET = 200
+    const WRITEFN_OFFSET = fieldoffset(GVC_s, findfirst(==(:write_fn), fieldnames(GVC_s)))
 
     function julia_io_initialize(firstjob::Ptr{Cvoid})
         #@show firstjob
@@ -192,7 +190,7 @@ module GraphViz
 
     function listPlugins(c,kind)
         s = Ref{Cint}()
-        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Cstring,Ptr{Cint},Cstring),c.handle,kind,s,C_NULL)
+        r = ccall((:gvPluginList,libgvc),Ptr{Ptr{UInt8}},(Ptr{Cvoid},Cstring,Ptr{Cint}),c.handle,kind,s)
         if r == C_NULL
             error("No Plugins available")
         end

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -45,15 +45,15 @@ end
 
 const julia_cairo_engine = Ref{gvdevice_engine_t}()
 const julia_cairo_features = Ref{gvdevice_features_t}(gvdevice_features_t(Int32(0),0.,0.,0.,0.,96.,96.))
-const julia_cairo_name = Vector{UInt8}("julia:cairo")
-const julia_cairo_libname = Vector{UInt8}("julia:cairo")
+const julia_cairo_name = "julia:cairo" # must be global to remain rooted for GC
+const julia_cairo_libname = "julia:cairo" # must be global to remain rooted for GC
 const julia_cairo_device = Ref{NTuple{2, gvplugin_installed_t}}()
 const julia_cairo_api = Ref{NTuple{2, gvplugin_api_t}}()
 
 function init_cairo_structs!()
     julia_cairo_engine[] = gvdevice_engine_t(@cfunction(cairo_initialize,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_format,Cvoid,(Ptr{Cvoid},)),@cfunction(cairo_finalize,Cvoid,(Ptr{Cvoid},)))
     julia_cairo_device[] = (
-        gvplugin_installed_t(Int32(0),pointer(julia_cairo_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_cairo_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_cairo_features)),
+        gvplugin_installed_t(Int32(0), unsafe_convert(Cstring, julia_cairo_name), Int32(0), unsafe_convert(Ptr{gvdevice_engine_t}, julia_cairo_engine), unsafe_convert(Ptr{gvdevice_features_t}, julia_cairo_features)),
         null(gvplugin_installed_t)
     )
     julia_cairo_api[] = (gvplugin_api_t(API_device, unsafe_convert(Ptr{gvplugin_installed_t}, julia_cairo_device)),
@@ -62,7 +62,7 @@ end
 
 function add_julia_cairo!(c::Context)
     lib = Ref{gvplugin_library_t}(gvplugin_library_t(
-        pointer(julia_cairo_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_cairo_api)))
+        unsafe_convert(Cstring, julia_cairo_libname),unsafe_convert(Ptr{gvplugin_api_t}, julia_cairo_api)))
     ccall((:gvAddLibrary,libgvc),Cvoid,(Ptr{Cvoid},Ptr{gvplugin_library_t}),c.handle,lib)
 end
 
@@ -76,7 +76,7 @@ function render(c::CairoContext,g::GraphViz.Graph; context = default_context[], 
     if !g.didlayout
         error("Must call layout before calling render!")
     end
-    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Any),context.handle,g.handle,format,c)
+    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Any),context.handle,g.handle,format,c)
 end
 
 function cairo_render(g::GraphViz.Graph; context = default_context[], format="julia:cairo")
@@ -85,7 +85,7 @@ function cairo_render(g::GraphViz.Graph; context = default_context[], format="ju
     if !g.didlayout
         error("Must call layout before calling render!")
     end
-    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Ptr{UInt8},Ptr{Cvoid}),context.handle,g.handle,format,C_NULL)
+    ccall((:gvRenderContext,libgvc),Cint,(Ptr{Cvoid},Ptr{Cvoid},Cstring,Ptr{Cvoid}),context.handle,g.handle,format,C_NULL)
     surface = last_surface
     last_surface = nothing
     return surface

--- a/src/capi.jl
+++ b/src/capi.jl
@@ -22,7 +22,7 @@ end
 
 struct gvplugin_installed_t
     id::Cint
-    ctype::Ptr{UInt8}
+    ctype::Cstring
     quality::Cint
     engine::Ptr{gvdevice_engine_t}
     features::Ptr{gvdevice_features_t}
@@ -70,7 +70,7 @@ struct gvplugin_api_t
 end
 
 struct gvplugin_library_t
-    name::Ptr{UInt8}
+    name::Cstring
     apis::Ptr{gvplugin_api_t}
 end
 
@@ -80,24 +80,24 @@ struct gvplugin_active_device_t
     engine::Ptr{gvdevice_engine_t}
     id::Cint
     features::Ptr{gvdevice_features_t}
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gvplugin_active_render_t
     engine::Ptr{Cvoid}
     id::Cint
     features::Ptr{Cvoid}
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gvplugin_active_loadimage_t
     engine::Ptr{Cvoid}
     id::Cint
-    ctype::Ptr{UInt8}
+    ctype::Cstring
 end
 
 struct gv_argvlist_t
-    argv::Ptr{Ptr{UInt8}}
+    argv::Ptr{Cstring}
     argc::Cint;
     alloc::Cint;
 end
@@ -126,8 +126,8 @@ end
 
 # TODO: These are probably wrong
 mutable struct GVCOMMON_s
-    info::Ptr{Ptr{UInt8}}
-    cmdname::Ptr{UInt8}
+    info::Ptr{Cstring}
+    cmdname::Cstring
     verbose::Cint
     config::UInt8
     auto_outfile_names::UInt8
@@ -142,10 +142,10 @@ end
 mutable struct GVC_s
     common::GVCOMMON_s
 
-    config_path::Ptr{UInt8}
+    config_path::Cstring
     config_found::UInt8
 
-    input_filenames::Ptr{Ptr{UInt8}}
+    input_filenames::Ptr{Cstring}
 
     gvgs::Ptr{Cvoid}
     gvg::Ptr{Cvoid}
@@ -177,18 +177,18 @@ mutable struct GVJ_s
     common::Ptr{Cvoid}
 
     obj_state::Ptr{Cvoid}
-    input_filename::Ptr{UInt8}
+    input_filename::Cstring
     graph_index::Cint
 
-    layout_type::Ptr{UInt8}
+    layout_type::Cstring
 
-    output_filename::Ptr{UInt8}
+    output_filename::Cstring
     output_file::Ptr{Cvoid}
     output_data::Ptr{UInt8}
     output_data_allocated::Cuint
     output_data_position::Cuint
 
-    output_langname::Ptr{UInt8}
+    output_langname::Cstring
     output_lang::Ptr{Cint}
 
     render::gvplugin_active_render_t
@@ -259,8 +259,8 @@ mutable struct GVJ_s
     current_obj::Ptr{Cvoid}
     selected_obj::Ptr{Cvoid}
 
-    active_tooltip::Ptr{UInt8}
-    selected_href::Ptr{UInt8}
+    active_tooltip::Cstring
+    selected_href::Cstring
 
     selected_obj_type_name::gv_argvlist_t
     selected_obj_attributes::gv_argvlist_t

--- a/src/capi.jl
+++ b/src/capi.jl
@@ -48,7 +48,6 @@ const GVDEVICE_COMPRESSED_FORMAT    = (1<<10)
 const GVDEVICE_NO_WRITER            = (1<<11)
 const GVRENDER_Y_GOES_DOWN          = (1<<12)
 const GVRENDER_DOES_TRANSFORM       = (1<<13)
-const GVRENDER_DOES_ARROWS          = (1<<14)
 const GVRENDER_DOES_LABELS          = (1<<15)
 const GVRENDER_DOES_MAPS            = (1<<16)
 const GVRENDER_DOES_MAP_RECTANGLE   = (1<<17)
@@ -96,12 +95,6 @@ struct gvplugin_active_loadimage_t
     ctype::Cstring
 end
 
-struct gv_argvlist_t
-    argv::Ptr{Cstring}
-    argc::Cint;
-    alloc::Cint;
-end
-
 struct Point{T}
     x::T
     y::T
@@ -124,16 +117,19 @@ struct gvdevice_callback_t
     render::Ptr{Cvoid}           # void (*render) (GVJ_t * job, const char *format, const char *filename);
 end
 
-# TODO: These are probably wrong
-mutable struct GVCOMMON_s
+# Mirrors of GVCOMMON_t (lib/gvc/gvcommon.h) and the leading fields of
+# GVC_t (lib/gvc/gvcint.h) as of graphviz 15.1.0. GVCOMMON_s must be an
+# immutable struct so that it is stored inline in GVC_s and field offsets
+# match the C layout.
+struct GVCOMMON_s
     info::Ptr{Cstring}
     cmdname::Cstring
     verbose::Cint
-    config::UInt8
-    auto_outfile_names::UInt8
+    config::Bool
+    auto_outfile_names::Bool
     errorfn::Ptr{Cvoid}
-    show_boxes::Ptr{Ptr{Cvoid}}
-    lib::Ptr{Ptr{Cvoid}}
+    show_boxes::Ptr{Cstring}
+    lib::Ptr{Cstring}
     viewNum::Cint
     builtins::Ptr{Cvoid}
     demand_loading::Cint
@@ -143,24 +139,16 @@ mutable struct GVC_s
     common::GVCOMMON_s
 
     config_path::Cstring
-    config_found::UInt8
+    config_found::Bool
 
     input_filenames::Ptr{Cstring}
+    fidx::Cint
 
     gvgs::Ptr{Cvoid}
     gvg::Ptr{Cvoid}
 
-    # Hack until tuples are properly inlined into types
-    apis0::Ptr{Cvoid}
-    apis1::Ptr{Cvoid}
-    apis2::Ptr{Cvoid}
-    apis3::Ptr{Cvoid}
-    apis4::Ptr{Cvoid}
-    api0::Ptr{Cvoid}
-    api1::Ptr{Cvoid}
-    api2::Ptr{Cvoid}
-    api3::Ptr{Cvoid}
-    api4::Ptr{Cvoid}
+    apis::NTuple{5,Ptr{Cvoid}}
+    api::NTuple{5,Ptr{Cvoid}}
     packages::Ptr{Cvoid}
 
     #  size_t (*write_fn) (GVJ_t *job, const char *s, size_t len);
@@ -176,7 +164,7 @@ mutable struct GVJ_s
 
     common::Ptr{Cvoid}
 
-    obj_state::Ptr{Cvoid}
+    obj::Ptr{Cvoid}
     input_filename::Cstring
     graph_index::Cint
 
@@ -185,11 +173,11 @@ mutable struct GVJ_s
     output_filename::Cstring
     output_file::Ptr{Cvoid}
     output_data::Ptr{UInt8}
-    output_data_allocated::Cuint
-    output_data_position::Cuint
+    output_data_allocated::Csize_t
+    output_data_position::Csize_t
 
     output_langname::Cstring
-    output_lang::Ptr{Cint}
+    output_lang::Cint
 
     render::gvplugin_active_render_t
     device::gvplugin_active_device_t
@@ -198,9 +186,9 @@ mutable struct GVJ_s
     callbacks::Ptr{gvdevice_callback_t}
 
     device_dpi::Pointf
-    device_sets_dpi::UInt8
+    device_sets_dpi::Bool
 
-    displat::Ptr{Cvoid}
+    display::Ptr{Cvoid}
     screen::Cint
 
     context::Ptr{Cvoid}
@@ -262,42 +250,24 @@ mutable struct GVJ_s
     active_tooltip::Cstring
     selected_href::Cstring
 
-    selected_obj_type_name::gv_argvlist_t
-    selected_obj_attributes::gv_argvlist_t
-
     window::Ptr{Cvoid}
 
     keybindings::Ptr{Cvoid}
-    numkeys::Cint
+    numkeys::Csize_t
     keycodes::Ptr{Cvoid}
 end
 
 # Disciplines
 
 
-struct Agmemdisc_s
-    #void *(*open) (Agdisc_t*);  /* independent of other resources */
-    open::Ptr{Cvoid}
-    #void *(*alloc) (void *state, size_t req);
-    alloc::Ptr{Cvoid}
-    #void *(*resize) (void *state, void *ptr, size_t old, size_t req);
-    resize::Ptr{Cvoid}
-    # void (*free) (void *state, void *ptr);
-    free::Ptr{Cvoid}
-    # void (*close) (void *state);
-    close::Ptr{Cvoid}
-end
-
 struct Agiddisc_s
     # void *(*open) (Agraph_t * g, Agdisc_t*);    /* associated with a graph */
     open::Ptr{Cvoid}
-    # long (*map) (void *state, int objtype, char *str, unsigned long *id, int createflag);
+    # long (*map) (void *state, int objtype, char *str, IDTYPE *id, int createflag);
     map::Ptr{Cvoid}
-    # long (*alloc) (void *state, int objtype, unsigned long id);
-    alloc::Ptr{Cvoid}
-    #void (*free) (void *state, int objtype, unsigned long id);
+    #void (*free) (void *state, int objtype, IDTYPE id);
     free::Ptr{Cvoid}
-    #char *(*print) (void *state, int objtype, unsigned long id);
+    #char *(*print) (void *state, int objtype, IDTYPE id);
     print::Ptr{Cvoid}
     #void (*close) (void *state);
     close::Ptr{Cvoid}
@@ -315,7 +285,6 @@ struct Agiodisc_s
 end
 
 struct Agdisc_s
-    mem::Ptr{Agmemdisc_s}
     id::Ptr{Agiddisc_s}
     io::Ptr{Agiodisc_s}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,3 +15,13 @@ graph graphname {
     @test_nowarn show(IOBuffer(), MIME"image/png"(), g)
 end
 
+@testset "listPlugins" begin
+    ctx = GraphViz.default_context[]
+    layouts = GraphViz.listPlugins(ctx, "layout")
+    @test layouts isa Vector{String}
+    @test "dot" in layouts
+    @test "neato" in layouts
+    # gvPluginList returns NULL for an unrecognized api kind
+    @test_throws ErrorException GraphViz.listPlugins(ctx, "nosuchapi")
+end
+


### PR DESCRIPTION
Dependent on https://github.com/JuliaGraphs/GraphViz.jl/pull/57.

This is primarily so that `GraphViz.jl` is supported on macOS AArch64.
That said, I am sure there were good updates somewhere within these ~13 major version bumps.

Struct changes done by Claude Fable 5 🤖 